### PR TITLE
Improve XRPL tx scanner 

### DIFF
--- a/integration-tests/xrpl/scanner_test.go
+++ b/integration-tests/xrpl/scanner_test.go
@@ -51,7 +51,7 @@ func TestFullHistoryScanAccountTx(t *testing.T) {
 	scanner := xrpl.NewAccountScanner(scannerCfg, chains.Log, rpcClient)
 	// add timeout to finish the tests in case of error
 
-	txsCh := make(chan rippledata.Transaction, txsCount)
+	txsCh := make(chan rippledata.TransactionWithMetaData, txsCount)
 	require.NoError(t, scanner.ScanTxs(ctx, txsCh))
 	t.Logf("Waiting for %d transactions to be scanned by the historycal scanner", len(writtenTxHashes))
 	validateTxsHashesInChannel(ctx, t, writtenTxHashes, txsCh)
@@ -104,7 +104,7 @@ func TestRecentHistoryScanAccountTx(t *testing.T) {
 		writtenTxHashes = sendMultipleTxs(ctx, t, 20, senderAcc, recipientAcc, chains.XRPL)
 	}()
 
-	txsCh := make(chan rippledata.Transaction, txsCount)
+	txsCh := make(chan rippledata.TransactionWithMetaData, txsCount)
 	require.NoError(t, scanner.ScanTxs(ctx, txsCh))
 
 	t.Logf("Waiting for %d transactions to be scanned by the recent scanner", len(writtenTxHashes))
@@ -144,7 +144,7 @@ func sendMultipleTxs(
 	return writtenTxHashes
 }
 
-func validateTxsHashesInChannel(ctx context.Context, t *testing.T, writtenTxHashes map[string]struct{}, txsCh chan rippledata.Transaction) {
+func validateTxsHashesInChannel(ctx context.Context, t *testing.T, writtenTxHashes map[string]struct{}, txsCh chan rippledata.TransactionWithMetaData) {
 	scanCtx, scanCtxCancel := context.WithTimeout(ctx, time.Minute)
 	defer scanCtxCancel()
 	// copy the original map
@@ -169,7 +169,7 @@ func validateTxsHashesInChannel(ctx context.Context, t *testing.T, writtenTxHash
 	}
 }
 
-func getTxHashesFromChannel(ctx context.Context, t *testing.T, txsCh chan rippledata.Transaction, count int) map[string]struct{} {
+func getTxHashesFromChannel(ctx context.Context, t *testing.T, txsCh chan rippledata.TransactionWithMetaData, count int) map[string]struct{} {
 	scanCtx, scanCtxCancel := context.WithTimeout(ctx, time.Minute)
 	defer scanCtxCancel()
 	txHashes := make(map[string]struct{}, count)

--- a/relayer/testutils/account.go
+++ b/relayer/testutils/account.go
@@ -1,0 +1,18 @@
+package testutils
+
+import (
+	"crypto/rand"
+
+	rippledata "github.com/rubblelabs/ripple/data"
+)
+
+// GenXRPLAccount generates random XRPL account.
+func GenXRPLAccount() rippledata.Account {
+	var acc rippledata.Account
+	buf := make([]byte, 20)
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
+	copy(acc[:], buf)
+	return acc
+}

--- a/relayer/xrpl/rpc.go
+++ b/relayer/xrpl/rpc.go
@@ -123,6 +123,7 @@ type AccountTxRequest struct {
 type AccountTxResult struct {
 	Marker       map[string]any              `json:"marker,omitempty"`
 	Transactions rippledata.TransactionSlice `json:"transactions,omitempty"`
+	Validated    bool                        `json:"validated"`
 }
 
 // ******************** RPC transport objects ********************

--- a/relayer/xrpl/scanner.go
+++ b/relayer/xrpl/scanner.go
@@ -65,7 +65,7 @@ func NewAccountScanner(cfg AccountScannerConfig, log logger.Logger, rpcTxProvide
 }
 
 // ScanTxs subscribes on rpc account transactions and continuously scans the recent and historical transactions.
-func (s *AccountScanner) ScanTxs(ctx context.Context, ch chan<- rippledata.Transaction) error {
+func (s *AccountScanner) ScanTxs(ctx context.Context, ch chan<- rippledata.TransactionWithMetaData) error {
 	s.log.Info("Subscribing xrpl scanner", logger.AnyFiled("config", s.cfg))
 	if s.cfg.RecentScanEnabled {
 		currentLedgerRes, err := s.rpcTxProvider.LedgerCurrent(ctx)
@@ -73,10 +73,6 @@ func (s *AccountScanner) ScanTxs(ctx context.Context, ch chan<- rippledata.Trans
 			return err
 		}
 		currentLedger := currentLedgerRes.LedgerCurrentIndex
-		if currentLedger <= s.cfg.RecentScanWindow {
-			return errors.Errorf("current ledger must be greater than the recent scan window, "+
-				"currentLedger:%d, recentScanWindow:%d", currentLedger, s.cfg.RecentScanWindow)
-		}
 		go s.scanRecentHistory(ctx, currentLedger, ch)
 	}
 
@@ -91,9 +87,14 @@ func (s *AccountScanner) ScanTxs(ctx context.Context, ch chan<- rippledata.Trans
 	return nil
 }
 
-func (s *AccountScanner) scanRecentHistory(ctx context.Context, currentLedger int64, ch chan<- rippledata.Transaction) {
-	minLedger := currentLedger - s.cfg.RecentScanWindow
-	s.doWithRetry(ctx, s.cfg.RepeatRecentScan, func() {
+func (s *AccountScanner) scanRecentHistory(ctx context.Context, currentLedger int64, ch chan<- rippledata.TransactionWithMetaData) {
+	// in case we don't have enough ledges for the window we start from the initla
+	minLedger := int64(0)
+	if currentLedger > s.cfg.RecentScanWindow {
+		minLedger = currentLedger - s.cfg.RecentScanWindow
+	}
+
+	s.doWithRepeat(ctx, s.cfg.RepeatRecentScan, func() {
 		s.log.Info("Scanning recent history", logger.Int64Filed("minLedger", minLedger))
 		lastLedger := s.scanTransactions(ctx, minLedger, ch)
 		if lastLedger != 0 {
@@ -103,15 +104,15 @@ func (s *AccountScanner) scanRecentHistory(ctx context.Context, currentLedger in
 	})
 }
 
-func (s *AccountScanner) scanFullHistory(ctx context.Context, ch chan<- rippledata.Transaction) {
-	s.doWithRetry(ctx, s.cfg.RepeatFullScan, func() {
+func (s *AccountScanner) scanFullHistory(ctx context.Context, ch chan<- rippledata.TransactionWithMetaData) {
+	s.doWithRepeat(ctx, s.cfg.RepeatFullScan, func() {
 		s.log.Info("Scanning full history")
 		lastLedger := s.scanTransactions(ctx, -1, ch)
 		s.log.Info("Scanning of full history is done", logger.Int64Filed("lastLedger", lastLedger))
 	})
 }
 
-func (s *AccountScanner) scanTransactions(ctx context.Context, minLedger int64, ch chan<- rippledata.Transaction) int64 {
+func (s *AccountScanner) scanTransactions(ctx context.Context, minLedger int64, ch chan<- rippledata.TransactionWithMetaData) int64 {
 	if minLedger <= 0 {
 		minLedger = -1
 	}
@@ -134,23 +135,28 @@ func (s *AccountScanner) scanTransactions(ctx context.Context, minLedger int64, 
 			return nil
 		})
 		if err != nil {
-			if isCtxError(err) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return lastLedger
 			}
 			// this panic is unexpected
 			panic(errors.Wrapf(err, "unexpected error received for the get account transactions with retry, err:%s", err.Error()))
 		}
-
-		for _, tx := range accountTxResult.Transactions {
-			// init prev processed ledger wasn't initialized we expect that we processed the prev ledger
-			if prevProcessedLedger == 0 {
-				prevProcessedLedger = int64(tx.LedgerSequence)
+		// we accept the transaction from the validated ledger only
+		if accountTxResult.Validated {
+			for _, tx := range accountTxResult.Transactions {
+				// init prev processed ledger wasn't initialized we expect that we processed the prev ledger
+				if prevProcessedLedger == 0 {
+					prevProcessedLedger = int64(tx.LedgerSequence)
+				}
+				if prevProcessedLedger < int64(tx.LedgerSequence) {
+					lastLedger = prevProcessedLedger
+					prevProcessedLedger = int64(tx.LedgerSequence)
+				}
+				if tx == nil {
+					continue
+				}
+				ch <- *tx
 			}
-			if prevProcessedLedger < int64(tx.LedgerSequence) {
-				lastLedger = prevProcessedLedger
-				prevProcessedLedger = int64(tx.LedgerSequence)
-			}
-			ch <- tx
 		}
 		if len(accountTxResult.Marker) == 0 {
 			lastLedger = prevProcessedLedger
@@ -162,23 +168,19 @@ func (s *AccountScanner) scanTransactions(ctx context.Context, minLedger int64, 
 	return lastLedger
 }
 
-func (s *AccountScanner) doWithRetry(ctx context.Context, shouldRetry bool, f func()) {
-	err := retry.Do(ctx, s.cfg.RetryDelay, func() error {
-		f()
-		if shouldRetry {
-			s.log.Info("Waiting before the next execution.", logger.StringFiled("retryDelay", s.cfg.RetryDelay.String()))
-			return retry.Retryable(errors.New("repeat scan"))
+func (s *AccountScanner) doWithRepeat(ctx context.Context, shouldRepeat bool, f func()) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			f()
+			if !shouldRepeat {
+				s.log.Info("Execution is fully stopped.")
+				return
+			}
+			s.log.Info("Waiting before the next execution.", logger.StringFiled("delay", s.cfg.RetryDelay.String()))
+			<-time.After(s.cfg.RetryDelay)
 		}
-		s.log.Info("Execution is fully stopped.")
-		return nil
-	})
-	if err == nil || isCtxError(err) {
-		return
 	}
-	// this panic is unexpected
-	panic(errors.Wrap(err, "unexpected error in do with resubscribe"))
-}
-
-func isCtxError(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/relayer/xrpl/scanner_mocks_test.go
+++ b/relayer/xrpl/scanner_mocks_test.go
@@ -8,10 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
+	xrpl "github.com/CoreumFoundation/coreumbridge-xrpl/relayer/xrpl"
 	gomock "github.com/golang/mock/gomock"
 	data "github.com/rubblelabs/ripple/data"
-
-	xrpl "github.com/CoreumFoundation/coreumbridge-xrpl/relayer/xrpl"
 )
 
 // MockRPCTxProvider is a mock of RPCTxProvider interface.


### PR DESCRIPTION
Improve XRPL tx scanner to read only validated transactions and automatically start from the initial ledger in case the recent scan window is too high

# Description

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreumbridge-xrpl/23)
<!-- Reviewable:end -->
