### PR TITLE
Contract: Modify queries to return empty results instead of key error

### DIFF
--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -1077,13 +1077,17 @@ fn query_available_tickets(deps: Deps) -> StdResult<AvailableTicketsResponse> {
 }
 
 fn query_fees_collected(deps: Deps, relayer_address: Addr) -> StdResult<FeesCollectedResponse> {
-    let fees_collected = FEES_COLLECTED.load(deps.storage, relayer_address)?;
+    let fees_collected = FEES_COLLECTED
+        .may_load(deps.storage, relayer_address)?
+        .unwrap_or_default();
 
     Ok(FeesCollectedResponse { fees_collected })
 }
 
 fn query_pending_refunds(deps: Deps, address: Addr) -> StdResult<PendingRefundsResponse> {
-    let pending_refunds = PENDING_REFUNDS.load(deps.storage, address)?;
+    let pending_refunds = PENDING_REFUNDS
+        .may_load(deps.storage, address)?
+        .unwrap_or_default();
 
     Ok(PendingRefundsResponse { pending_refunds })
 }

--- a/contract/src/tests.rs
+++ b/contract/src/tests.rs
@@ -1892,6 +1892,18 @@ mod tests {
             .unwrap();
         assert_eq!(request_balance.balance, amount_to_send.to_string());
 
+        // If we try to query pending refunds for any address that has no pending refunds, it should return an empty array
+        let query_pending_refunds = wasm
+            .query::<QueryMsg, PendingRefundsResponse>(
+                &contract_addr,
+                &QueryMsg::PendingRefunds {
+                    address: Addr::unchecked("any_address"),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(query_pending_refunds.pending_refunds, vec![]);
+
         // Let's verify the pending refunds and try to claim them
         let query_pending_refunds = wasm
             .query::<QueryMsg, PendingRefundsResponse>(
@@ -4627,6 +4639,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(request_balance.balance, "1000000000000000".to_string());
+
+        // If we query fees for any random address that has no fees collected, it should return an empty array
+        let query_fees_collected = wasm
+            .query::<QueryMsg, FeesCollectedResponse>(
+                &contract_addr,
+                &QueryMsg::FeesCollected {
+                    relayer_address: Addr::unchecked("any_address"),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(query_fees_collected.fees_collected, vec![]);
 
         let query_fees_collected = wasm
             .query::<QueryMsg, FeesCollectedResponse>(


### PR DESCRIPTION
# Description
Modified queries that access maps in the state so that if the address is not in the map, we will return an empty array as a result (like in regular Cosmos SDK queries) instead of a key not found error.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [x] Provide a concise and meaningful description
- [x] Review the code yourself first, before making the PR.
- [x] Annotate your PR in places that require explanation.
- [x] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreumbridge-xrpl/81)
<!-- Reviewable:end -->
