### PR TITLE
Contract: Add XRPL transaction hash to pending refunds

### DIFF
--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -676,6 +676,7 @@ fn save_evidence(
                         handle_coreum_to_xrpl_transfer_confirmation(
                             deps.storage,
                             transaction_result.to_owned(),
+                            tx_hash.clone(),
                             operation_id,
                             &mut response,
                         )?;
@@ -1427,6 +1428,7 @@ fn query_pending_refunds(
             last_key = Some(key);
             PendingRefund {
                 id: pr.id,
+                xrpl_tx_hash: pr.xrpl_tx_hash,
                 coin: pr.coin,
             }
         })

--- a/contract/src/msg.rs
+++ b/contract/src/msg.rs
@@ -198,6 +198,7 @@ pub struct PendingRefundsResponse {
 #[cw_serde]
 pub struct PendingRefund {
     pub id: String,
+    pub xrpl_tx_hash: Option<String>,
     pub coin: Coin,
 }
 

--- a/contract/src/operation.rs
+++ b/contract/src/operation.rs
@@ -138,6 +138,7 @@ pub fn handle_trust_set_confirmation(
 pub fn handle_coreum_to_xrpl_transfer_confirmation(
     storage: &mut dyn Storage,
     transaction_result: TransactionResult,
+    tx_hash: Option<String>,
     operation_id: u64,
     response: &mut Response<CoreumMsg>,
 ) -> Result<(), ContractError> {
@@ -172,6 +173,7 @@ pub fn handle_coreum_to_xrpl_transfer_confirmation(
                         store_pending_refund(
                             storage,
                             pending_operation.id,
+                            tx_hash,
                             sender,
                             coin(amount_sent.u128(), xrpl_token.coreum_denom),
                         )?;
@@ -197,6 +199,7 @@ pub fn handle_coreum_to_xrpl_transfer_confirmation(
                                 store_pending_refund(
                                     storage,
                                     pending_operation.id,
+                                    tx_hash,
                                     sender,
                                     coin(amount_to_send_back.u128(), token.denom),
                                 )?;
@@ -220,12 +223,14 @@ pub fn handle_coreum_to_xrpl_transfer_confirmation(
 pub fn store_pending_refund(
     storage: &mut dyn Storage,
     pending_operation_id: String,
+    xrpl_tx_hash: Option<String>,
     receiver: Addr,
     coin: Coin,
 ) -> Result<(), ContractError> {
     // We store the pending refund for this user and this pending_operation_id
     let pending_refund = PendingRefund {
         address: receiver.to_owned(),
+        xrpl_tx_hash,
         id: pending_operation_id.to_owned(),
         coin,
     };

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -94,6 +94,9 @@ pub struct PendingRefund {
     pub address: Addr,
     // We will use a unique id (block timestamp - operation_id) for users to claim their funds back per operation id
     pub id: String,
+    // Transaction hash in XRPL that failed to be able to track it and find reason for failure
+    // Optional because Invalid transactions don't have a transaction hash because they are never executed
+    pub xrpl_tx_hash: Option<String>,
     pub coin: Coin,
 }
 

--- a/contract/src/tests.rs
+++ b/contract/src/tests.rs
@@ -2102,12 +2102,13 @@ mod tests {
             }
         );
 
+        let tx_hash = generate_hash();
         // Reject the operation, therefore the tokens should be stored in the pending refunds (except for truncated amount).
         wasm.execute::<ExecuteMsg>(
             &contract_addr,
             &ExecuteMsg::SaveEvidence {
                 evidence: Evidence::XRPLTransactionResult {
-                    tx_hash: Some(generate_hash()),
+                    tx_hash: Some(tx_hash.clone()),
                     account_sequence: query_pending_operations.operations[0].account_sequence,
                     ticket_sequence: query_pending_operations.operations[0].ticket_sequence,
                     transaction_result: TransactionResult::Rejected,
@@ -2155,6 +2156,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(query_pending_refunds.pending_refunds.len(), 1);
+        assert_eq!(
+            query_pending_refunds.pending_refunds[0].xrpl_tx_hash,
+            Some(tx_hash)
+        );
         // Truncated amount (1) is not refundable
         assert_eq!(
             query_pending_refunds.pending_refunds[0].coin,


### PR DESCRIPTION
# Description
Add the XRPL transaction hash of the failed transaction (if available) to pending refunds, to easily track the transaction that failed and why.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreumbridge-xrpl/129)
<!-- Reviewable:end -->
