### PR TITLE
Add Contract Binary to release CI Action

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.81.0
+          toolchain: 1.82.0
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
       - name: Lint contract

--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81.0
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
       - name: Lint contract
         run: make lint-contract
       - name: Build contract

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build binaries
         run: make release
+      - name: Build contract
+        run: make build-contract
       - name: Build and publish images
         run: make release-images
       - name: Check Tag
@@ -37,7 +39,8 @@ jobs:
           ln bin/.cache/coreumbridge-xrpl-relayer/docker.linux.arm64/bin/coreumbridge-xrpl-relayer coreumbridge-xrpl-relayer-linux-arm64
           ln bin/.cache/coreumbridge-xrpl-relayer/docker.darwin.amd64/bin/coreumbridge-xrpl-relayer coreumbridge-xrpl-relayer-darwin-amd64
           ln bin/.cache/coreumbridge-xrpl-relayer/docker.darwin.arm64/bin/coreumbridge-xrpl-relayer coreumbridge-xrpl-relayer-darwin-arm64
-          sha256sum coreumbridge-xrpl-relayer-* > checksums.txt
+          ln contract/artifacts/coreumbridge_xrpl.wasm coreumbridge_xrpl.wasm
+          sha256sum coreumbridge-xrpl-relayer-* coreumbridge_xrpl.wasm > checksums.txt
       - name: Create release
         if: steps.check-tag.outputs.release == 'true'
         uses: softprops/action-gh-release@v2
@@ -49,6 +52,7 @@ jobs:
             coreumbridge-xrpl-relayer-linux-arm64
             coreumbridge-xrpl-relayer-darwin-amd64
             coreumbridge-xrpl-relayer-darwin-arm64
+            coreumbridge_xrpl.wasm
             checksums.txt
       - name: Create release candidate
         if: steps.check-tag.outputs.release_candidate == 'true'
@@ -62,4 +66,5 @@ jobs:
             coreumbridge-xrpl-relayer-linux-arm64
             coreumbridge-xrpl-relayer-darwin-amd64
             coreumbridge-xrpl-relayer-darwin-arm64
+            coreumbridge_xrpl.wasm
             checksums.txt

--- a/contract/rust-toolchain.toml
+++ b/contract/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.81.0"
+target = "wasm32-unknown-unknown"

--- a/contract/rust-toolchain.toml
+++ b/contract/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 target = "wasm32-unknown-unknown"


### PR DESCRIPTION
# Description

This pull request updates the CI and release workflows to improve Rust toolchain management and ensure the contract WebAssembly (`.wasm`) artifact is built and included in releases. The changes standardize Rust version usage, automate contract building, and ensure the `.wasm` file is published with checksums.

**CI and Toolchain Management:**
* Added explicit installation of Rust toolchain version `1.82.0` with required targets and components (`wasm32-unknown-unknown`, `rustfmt`, `clippy`) in the contract CI workflow (`.github/workflows/contract-ci.yml`).
* Added a `rust-toolchain.toml` file in the `contract` directory to pin the Rust toolchain version and target for consistent local and CI builds.

**Release Workflow Improvements:**
* Added a `make build-contract` step to the release workflow to ensure the contract is built during releases (`.github/workflows/release.yml`).
* Modified the release artifact preparation to include the built `coreumbridge_xrpl.wasm` file and add it to the SHA256 checksum calculation (`.github/workflows/release.yml`).
* Updated the release and release candidate steps to upload the `coreumbridge_xrpl.wasm` artifact alongside binaries and checksums 

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreumbridge-xrpl/222)
<!-- Reviewable:end -->
