### PR TITLE
Replace contract migrate version with v1.1.7

### DIFF
--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	// CoreumBridgeXRPLWASMV110 is the previous version of bridge smart contract.
-	CoreumBridgeXRPLWASMV110 tools.Name = "coreumbridge-xrpl-wasm-v1.1.0"
+	// CoreumBridgeXRPLWASMV117 is the previous version of bridge smart contract.
+	CoreumBridgeXRPLWASMV117 tools.Name = "coreumbridge-xrpl-wasm-v1.1.7"
 
 	// Mockgen is used to generate mock files.
 	Mockgen tools.Name = "mockgen"
@@ -19,15 +19,15 @@ const (
 var Tools = []tools.Tool{
 	// https://github.com/CoreumFoundation/coreumbridge-xrpl/releases
 	tools.BinaryTool{
-		Name:    CoreumBridgeXRPLWASMV110,
-		Version: "v1.1.0",
+		Name:    CoreumBridgeXRPLWASMV117,
+		Version: "v1.1.7",
 		Local:   true,
 		Sources: tools.Sources{
 			tools.TargetPlatformLocal: {
-				URL:  "https://github.com/CoreumFoundation/coreumbridge-xrpl/releases/download/v1.1.0/coreumbridge_xrpl.wasm",
-				Hash: "sha256:9e458f31599f20a8c608056ca89ed82cc00f97c8d2ff415dd83fb95389e3e32f",
+				URL:  "https://github.com/CoreumFoundation/coreumbridge-xrpl/releases/download/v1.1.7/coreumbridge_xrpl.wasm",
+				Hash: "sha256:02a4cdb98ee891664ee5081209a1b55a7c7e3e4b01455009f4466b3a280de6dc",
 				Binaries: map[string]string{
-					"bin/coreumbridge-xrpl-v1.1.0.wasm": "coreumbridge_xrpl.wasm",
+					"bin/coreumbridge-xrpl-v1.1.7.wasm": "coreumbridge_xrpl.wasm",
 				},
 			},
 		},
@@ -43,7 +43,7 @@ var Tools = []tools.Tool{
 
 // EnsureBridgeXRPLWASM ensures bridge smart contract is available.
 func EnsureBridgeXRPLWASM(ctx context.Context, _ types.DepsFunc) error {
-	return tools.Ensure(ctx, CoreumBridgeXRPLWASMV110, tools.TargetPlatformLocal)
+	return tools.Ensure(ctx, CoreumBridgeXRPLWASMV117, tools.TargetPlatformLocal)
 }
 
 // EnsureMockgen ensures that mockgen is available.

--- a/integration-tests/contract.go
+++ b/integration-tests/contract.go
@@ -28,7 +28,7 @@ func DeployInstantiateAndMigrateContract(
 ) (sdk.AccAddress, *coreum.ContractClient) {
 	t.Helper()
 
-	owner, contractClient := DeployAndInstantiateContractV110(
+	owner, contractClient := DeployAndInstantiateContractV117(
 		ctx,
 		t,
 		chains,
@@ -61,8 +61,8 @@ func MigrateContract(
 	require.NoError(t, err)
 }
 
-// DeployAndInstantiateContractV110 deploys and instantiates the mainnet version of the contract.
-func DeployAndInstantiateContractV110(
+// DeployAndInstantiateContractV117 deploys and instantiates the mainnet version of the contract.
+func DeployAndInstantiateContractV117(
 	ctx context.Context,
 	t *testing.T,
 	chains Chains,

--- a/integration-tests/contract/migration_test.go
+++ b/integration-tests/contract/migration_test.go
@@ -23,7 +23,7 @@ func TestContractMigration(t *testing.T) {
 
 	xrplBridgeAddress := xrpl.GenPrivKeyTxSigner().Account()
 	xrplBaseFee := uint32(10)
-	owner, contractClient := integrationtests.DeployAndInstantiateContractV110(
+	owner, contractClient := integrationtests.DeployAndInstantiateContractV117(
 		ctx,
 		t,
 		chains,

--- a/integration-tests/init.go
+++ b/integration-tests/init.go
@@ -37,7 +37,7 @@ func init() {
 	flag.StringVar(&coreumCfg.GRPCAddress, "coreum-grpc-address", "localhost:9090", "GRPC address of cored node started by coreum")
 	flag.StringVar(&coreumCfg.FundingMnemonic, "coreum-funding-mnemonic", "sad hobby filter tray ordinary gap half web cat hard call mystery describe member round trend friend beyond such clap frozen segment fan mistake", "Funding coreum account mnemonic required by tests")
 	flag.StringVar(&coreumCfg.ContractPath, "coreum-contract-path", "../../contract/artifacts/coreumbridge_xrpl.wasm", "Path to smart contract bytecode")
-	flag.StringVar(&coreumCfg.PreviousContractPath, "coreum-previous-contract-path", "../../bin/coreumbridge-xrpl-v1.1.0.wasm", "Path to previous smart contract bytecode")
+	flag.StringVar(&coreumCfg.PreviousContractPath, "coreum-previous-contract-path", "../../bin/coreumbridge-xrpl-v1.1.7.wasm", "Path to previous smart contract bytecode")
 	flag.StringVar(&xrplCfg.RPCAddress, "xrpl-rpc-address", "http://localhost:5005", "RPC address of xrpl node")
 	flag.StringVar(&xrplCfg.FundingSeed, "xrpl-funding-seed", "snoPBrXtMeMyMHUVTgbuqAfg1SUTb", "Funding XRPL account seed required by tests")
 	// this is the default address used in znet


### PR DESCRIPTION
# Description

This pull request updates the bridge smart contract version used throughout the codebase from v1.1.0 to v1.1.7. The changes ensure that all references, downloads, and integrations now use the new version, including updates to binary URLs, hash values, and code identifiers.

**Bridge contract version upgrade:**

* Updated the constant in `build/tools/tools.go` to use `CoreumBridgeXRPLWASMV117` instead of `CoreumBridgeXRPLWASMV110`, reflecting the new contract version.
* Changed the binary tool configuration in `build/tools/tools.go` to download v1.1.7 of the bridge contract, including the new URL, hash, and binary path.
* Updated the bridge contract ensure function in `build/tools/tools.go` to use the new version constant.

**Integration test updates:**

* Renamed the deployment and instantiation function in `integration-tests/contract.go` from `DeployAndInstantiateContractV110` to `DeployAndInstantiateContractV117`, and updated all usages to call the new function.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreumbridge-xrpl/223)
<!-- Reviewable:end -->
